### PR TITLE
Make unity build and precompiled headers optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(OpenSG CXX)
 cmake_minimum_required(VERSION 3.12)
 
 if (${CMAKE_VERSION} GREATER_EQUAL 3.16)
-    set(CMAKE_UNITY_BUILD On)
+    option(OPENSG_USE_PRECOMPILED_HEADERS "Turn on generation of precompiled headers" OFF)
     set(CMAKE_UNITY_BUILD_BATCH_SIZE 20)
 endif()
 

--- a/OSGBase/CMakeLists.txt
+++ b/OSGBase/CMakeLists.txt
@@ -16,7 +16,7 @@ file(GLOB HEADER_FILES *.h *.inl)
 add_library(${TARGET_NAME} SHARED ${SOURCE_FILES} ${SOURCE_FILES})
 set_target_properties(${TARGET_NAME} PROPERTIES DEBUG_POSTFIX "D")
 
-if (${CMAKE_VERSION} GREATER_EQUAL 3.16)
+if (OPENSG_USE_PRECOMPILED_HEADERS)
 	target_precompile_headers(${TARGET_NAME} PRIVATE precompiled.pch)
 endif()
 

--- a/OSGSystem/CMakeLists.txt
+++ b/OSGSystem/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(${TARGET_NAME} SHARED ${SOURCE_FILES} ${HEADER_FILES})
 set_target_properties(${TARGET_NAME} PROPERTIES DEBUG_POSTFIX "D")
 
 
-if (${CMAKE_VERSION} GREATER_EQUAL 3.16)
+if (OPENSG_USE_PRECOMPILED_HEADERS)
     file(GLOB LEX_SOURCES LexGenerated/*.cpp LexGenerated/*.cc)
 
     foreach(FILE IN LISTS LEX_SOURCES)


### PR DESCRIPTION
Especially the Linux runners of Github Actions seem to benefit more from ccache when precompiled headers are deactivated.