### PR TITLE
Fix OpenSG for VS2022

### DIFF
--- a/OSGBase/OSGReal16.cpp
+++ b/OSGBase/OSGReal16.cpp
@@ -66153,9 +66153,9 @@ short Real16::convert(int i) {
   // of float and half (127 versus 15).
   //
 
-  register int s = (i >> 16) & 0x00008000;
-  register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
-  register int m = i & 0x007fffff;
+  int s = (i >> 16) & 0x00008000;
+  int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+  int m = i & 0x007fffff;
 
   //
   // Now reassemble s, e and m into a half:

--- a/OSGBase/OSGReal16.h
+++ b/OSGBase/OSGReal16.h
@@ -436,7 +436,7 @@ inline Real16::Real16(float f) {
 
     x.f = f;
 
-    register int e = (x.i >> 23) & 0x000001ff;
+    int e = (x.i >> 23) & 0x000001ff;
 
     e = _eLut[e];
 

--- a/OSGBase/OSGTime.inl
+++ b/OSGBase/OSGTime.inl
@@ -68,7 +68,7 @@ inline TimeStamp getTimeStamp(void) {
   return static_cast<TimeStamp>(iCounter);
 #elif defined(__linux) && defined(__i386)
 
-  register uint64_t result;
+  uint64_t result;
   // asm volatile ("rdtsc" : "=A"(result));
   asm volatile(".byte 0x0f, 0x31"
                : "=A"(result)); // same thing as rdtsc... inject the bytes for the opcode.

--- a/OSGSystem/LexGenerated/OSGScanParseSkel.lex.cpp
+++ b/OSGSystem/LexGenerated/OSGScanParseSkel.lex.cpp
@@ -707,7 +707,7 @@ YY_DECL {
     *yy_state_ptr++  = yy_current_state;
   yy_match:
     do {
-      register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+      YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
       while (yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state) {
         yy_current_state = (int)yy_def[yy_current_state];
         if (yy_current_state >= 389)
@@ -1676,9 +1676,9 @@ void yyFlexLexer::LexerOutput(const char* buf, int size) {
  */
 
 int yyFlexLexer::yy_get_next_buffer() {
-  register char* dest   = yy_current_buffer->yy_ch_buf;
-  register char* source = OSGScanParseSkel_text_ptr;
-  register int   number_to_move, i;
+  char* dest   = yy_current_buffer->yy_ch_buf;
+  char* source = OSGScanParseSkel_text_ptr;
+  int   number_to_move, i;
   int            ret_val;
 
   if (yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1])
@@ -1788,15 +1788,15 @@ int yyFlexLexer::yy_get_next_buffer() {
 /* yy_get_previous_state - get the state just before the EOB char was reached */
 
 yy_state_type yyFlexLexer::yy_get_previous_state() {
-  register yy_state_type yy_current_state;
-  register char*         yy_cp;
+  yy_state_type yy_current_state;
+  char*         yy_cp;
 
   yy_current_state = yy_start;
   yy_state_ptr     = yy_state_buf;
   *yy_state_ptr++  = yy_current_state;
 
   for (yy_cp = OSGScanParseSkel_text_ptr + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp) {
-    register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+    YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
     while (yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state) {
       yy_current_state = (int)yy_def[yy_current_state];
       if (yy_current_state >= 389)
@@ -1816,9 +1816,9 @@ yy_state_type yyFlexLexer::yy_get_previous_state() {
  */
 
 yy_state_type yyFlexLexer::yy_try_NUL_trans(yy_state_type yy_current_state) {
-  register int yy_is_jam;
+  int yy_is_jam;
 
-  register YY_CHAR yy_c = 1;
+  YY_CHAR yy_c = 1;
   while (yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state) {
     yy_current_state = (int)yy_def[yy_current_state];
     if (yy_current_state >= 389)
@@ -1832,17 +1832,17 @@ yy_state_type yyFlexLexer::yy_try_NUL_trans(yy_state_type yy_current_state) {
   return yy_is_jam ? 0 : yy_current_state;
 }
 
-void yyFlexLexer::yyunput(int c, register char* yy_bp) {
-  register char* yy_cp = yy_c_buf_p;
+void yyFlexLexer::yyunput(int c, char* yy_bp) {
+  char* yy_cp = yy_c_buf_p;
 
   /* undo effects of setting up yytext */
   *yy_cp = yy_hold_char;
 
   if (yy_cp < yy_current_buffer->yy_ch_buf + 2) { /* need to shift things up to make room */
     /* +2 for EOB chars. */
-    register int   number_to_move = yy_n_chars + 2;
-    register char* dest   = &yy_current_buffer->yy_ch_buf[yy_current_buffer->yy_buf_size + 2];
-    register char* source = &yy_current_buffer->yy_ch_buf[number_to_move];
+    int   number_to_move = yy_n_chars + 2;
+    char* dest   = &yy_current_buffer->yy_ch_buf[yy_current_buffer->yy_buf_size + 2];
+    char* source = &yy_current_buffer->yy_ch_buf[number_to_move];
 
     while (source > yy_current_buffer->yy_ch_buf)
       *--dest = *--source;
@@ -2118,7 +2118,7 @@ yyconst char*     s2;
 int               n;
 #endif
 {
-  register int i;
+  int i;
   for (i = 0; i < n; ++i)
     s1[i] = s2[i];
 }
@@ -2131,7 +2131,7 @@ static int yy_flex_strlen(yyconst char* s)
 static int        yy_flex_strlen(s) yyconst char* s;
 #endif
 {
-  register int n;
+  int n;
   for (n = 0; s[n]; ++n)
     ;
 

--- a/OSGSystem/LexGenerated/OSGScanParseSkel.lex.cpp
+++ b/OSGSystem/LexGenerated/OSGScanParseSkel.lex.cpp
@@ -654,9 +654,9 @@ YY_MALLOC_DECL
 #define YY_RULE_SETUP YY_USER_ACTION
 
 YY_DECL {
-  register yy_state_type yy_current_state;
-  register char *        yy_cp, *yy_bp;
-  register int           yy_act;
+  yy_state_type yy_current_state;
+  char *        yy_cp, *yy_bp;
+  int           yy_act;
 
 #line 83 "../../../Source/System/FileIO/ScanParseSkel/OSGScanParseSkel.lpp"
 

--- a/OSGSystem/LexGenerated/OSGScanParseSkel.tab.cpp
+++ b/OSGSystem/LexGenerated/OSGScanParseSkel.tab.cpp
@@ -773,9 +773,9 @@ static void  __yy_memcpy(to, from, count) char* to;
 char*        from;
 unsigned int count;
 {
-  register char* f = from;
-  register char* t = to;
-  register int   i = count;
+  char* f = from;
+  char* t = to;
+  int   i = count;
 
   while (i-- > 0)
     *t++ = *f++;

--- a/OSGSystem/LexGenerated/OSGScanParseSkel.tab.cpp
+++ b/OSGSystem/LexGenerated/OSGScanParseSkel.tab.cpp
@@ -786,9 +786,9 @@ unsigned int count;
 /* This is the most reliable way to avoid incompatibilities
    in available built-in functions on various systems.  */
 static void __yy_memcpy(char* to, char* from, unsigned int count) {
-  register char* t = to;
-  register char* f = from;
-  register int   i = count;
+  char* t = to;
+  char* f = from;
+  int   i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -828,10 +828,10 @@ int yyparse(void);
 #endif
 
 int yyparse(YYPARSE_PARAM_ARG) YYPARSE_PARAM_DECL {
-  register int      yystate;
-  register int      yyn;
-  register short*   yyssp;
-  register YYSTYPE* yyvsp;
+  int      yystate;
+  int      yyn;
+  short*   yyssp;
+  YYSTYPE* yyvsp;
   int               yyerrstatus; /*  number of tokens to shift before error messages enabled */
   int               yychar1 = 0; /*  lookahead token as an internal (translated) token number */
 

--- a/OSGSystem/LexGenerated/v2a.lex.cpp
+++ b/OSGSystem/LexGenerated/v2a.lex.cpp
@@ -673,9 +673,9 @@ YY_MALLOC_DECL
 #define YY_RULE_SETUP YY_USER_ACTION
 
 YY_DECL {
-  register yy_state_type yy_current_state;
-  register char *        yy_cp, *yy_bp;
-  register int           yy_act;
+  yy_state_type yy_current_state;
+  char *        yy_cp, *yy_bp;
+  int           yy_act;
 
 #line 62 "../../../Experimental/VRMLLoader/v2a.l"
 

--- a/OSGSystem/LexGenerated/v2a.lex.cpp
+++ b/OSGSystem/LexGenerated/v2a.lex.cpp
@@ -720,7 +720,7 @@ YY_DECL {
     *yy_state_ptr++  = yy_current_state;
   yy_match:
     do {
-      register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+      YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
       while (yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state) {
         yy_current_state = (int)yy_def[yy_current_state];
         if (yy_current_state >= 244)
@@ -1287,9 +1287,9 @@ YY_DECL {
  */
 
 static int yy_get_next_buffer() {
-  register char* dest   = yy_current_buffer->yy_ch_buf;
-  register char* source = yytext_ptr;
-  register int   number_to_move, i;
+  char* dest   = yy_current_buffer->yy_ch_buf;
+  char* source = yytext_ptr;
+  int   number_to_move, i;
   int            ret_val;
 
   if (yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1])
@@ -1399,15 +1399,15 @@ static int yy_get_next_buffer() {
 /* yy_get_previous_state - get the state just before the EOB char was reached */
 
 static yy_state_type yy_get_previous_state() {
-  register yy_state_type yy_current_state;
-  register char*         yy_cp;
+  yy_state_type yy_current_state;
+  char*         yy_cp;
 
   yy_current_state = yy_start;
   yy_state_ptr     = yy_state_buf;
   *yy_state_ptr++  = yy_current_state;
 
   for (yy_cp = yytext_ptr + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp) {
-    register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+    YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
     while (yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state) {
       yy_current_state = (int)yy_def[yy_current_state];
       if (yy_current_state >= 244)
@@ -1432,9 +1432,9 @@ static yy_state_type yy_try_NUL_trans(yy_state_type yy_current_state)
 static yy_state_type yy_try_NUL_trans(yy_current_state) yy_state_type yy_current_state;
 #endif
 {
-  register int yy_is_jam;
+  int yy_is_jam;
 
-  register YY_CHAR yy_c = 1;
+  YY_CHAR yy_c = 1;
   while (yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state) {
     yy_current_state = (int)yy_def[yy_current_state];
     if (yy_current_state >= 244)
@@ -1450,22 +1450,22 @@ static yy_state_type yy_try_NUL_trans(yy_current_state) yy_state_type yy_current
 
 #ifndef YY_NO_UNPUT
 #ifdef YY_USE_PROTOS
-static void yyunput(int c, register char* yy_bp)
+static void yyunput(int c, char* yy_bp)
 #else
 static void       yyunput(c, yy_bp) int c;
-register char*    yy_bp;
+char*    yy_bp;
 #endif
 {
-  register char* yy_cp = yy_c_buf_p;
+  char* yy_cp = yy_c_buf_p;
 
   /* undo effects of setting up yytext */
   *yy_cp = yy_hold_char;
 
   if (yy_cp < yy_current_buffer->yy_ch_buf + 2) { /* need to shift things up to make room */
     /* +2 for EOB chars. */
-    register int   number_to_move = yy_n_chars + 2;
-    register char* dest   = &yy_current_buffer->yy_ch_buf[yy_current_buffer->yy_buf_size + 2];
-    register char* source = &yy_current_buffer->yy_ch_buf[number_to_move];
+    int   number_to_move = yy_n_chars + 2;
+    char* dest   = &yy_current_buffer->yy_ch_buf[yy_current_buffer->yy_buf_size + 2];
+    char* source = &yy_current_buffer->yy_ch_buf[number_to_move];
 
     while (source > yy_current_buffer->yy_ch_buf)
       *--dest = *--source;
@@ -1885,7 +1885,7 @@ yyconst char*     s2;
 int               n;
 #endif
 {
-  register int i;
+  int i;
   for (i = 0; i < n; ++i)
     s1[i] = s2[i];
 }
@@ -1898,7 +1898,7 @@ static int yy_flex_strlen(yyconst char* s)
 static int        yy_flex_strlen(s) yyconst char* s;
 #endif
 {
-  register int n;
+  int n;
   for (n = 0; s[n]; ++n)
     ;
 

--- a/OSGSystem/LexGenerated/v2a.tab.cpp
+++ b/OSGSystem/LexGenerated/v2a.tab.cpp
@@ -359,9 +359,9 @@ unsigned int count;
 __yy_memcpy(char* to, const char* from, unsigned int count)
 #endif
 {
-  register const char* f = from;
-  register char*       t = to;
-  register int         i = count;
+  const char* f = from;
+  char*       t = to;
+  int         i = count;
 
   while (i-- > 0)
     *t++ = *f++;

--- a/OSGSystem/LexGenerated/v2a.tab.cpp
+++ b/OSGSystem/LexGenerated/v2a.tab.cpp
@@ -434,8 +434,8 @@ int yyparse(YYPARSE_PARAM_ARG) YYPARSE_PARAM_DECL {
   YY_DECL_VARIABLES
 #endif /* !YYPURE */
 
-  register int yystate;
-  register int yyn;
+  int yystate;
+  int yyn;
   /* Number of tokens to shift before error messages enabled.  */
   int yyerrstatus;
   /* Lookahead token as an internal (translated) token number.  */
@@ -452,12 +452,12 @@ int yyparse(YYPARSE_PARAM_ARG) YYPARSE_PARAM_DECL {
   /* The state stack. */
   short           yyssa[YYINITDEPTH];
   short*          yyss = yyssa;
-  register short* yyssp;
+  short* yyssp;
 
   /* The semantic value stack.  */
   YYSTYPE           yyvsa[YYINITDEPTH];
   YYSTYPE*          yyvs = yyvsa;
-  register YYSTYPE* yyvsp;
+  YYSTYPE* yyvsp;
 
 #if YYLSP_NEEDED
   /* The location stack.  */

--- a/OSGSystem/OSGGIFImageFileType.cpp
+++ b/OSGSystem/OSGGIFImageFileType.cpp
@@ -959,7 +959,7 @@ static int nextLWZ(std::istream& is) {
   static int   table[2][(1 << MAX_LWZ_BITS)];
   static int   firstcode, oldcode;
   int          code, incode;
-  register int i;
+  int i;
 
   while ((code = nextCode(is, code_size)) >= 0) {
     if (code == clear_code) {

--- a/OSGSystem/OSGParticleBSP.cpp
+++ b/OSGSystem/OSGParticleBSP.cpp
@@ -44,6 +44,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <functional>
 
 #include <OSGConfig.h>
 

--- a/OSGSystem/OSGPipelineComposer.h
+++ b/OSGSystem/OSGPipelineComposer.h
@@ -49,6 +49,8 @@
 #include <OSGBaseThread.h>
 #include <OSGLock.h>
 
+#include <functional>
+
 OSG_BEGIN_NAMESPACE
 
 //#define USE_NV_OCCLUSION 1

--- a/OSGSystem/OSGSortLastWindow.h
+++ b/OSGSystem/OSGSortLastWindow.h
@@ -45,6 +45,7 @@
 #include <utility>
 #include <vector>
 #include <queue>
+#include <functional>
 
 #include <OSGConfig.h>
 #include <OSGRenderAction.h>

--- a/OSGSystem/OSGState.cpp
+++ b/OSGSystem/OSGState.cpp
@@ -42,6 +42,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <functional>
 
 #include "OSGConfig.h"
 

--- a/OSGSystem/OSGTTVectorFontGlyph.cpp
+++ b/OSGSystem/OSGTTVectorFontGlyph.cpp
@@ -155,7 +155,7 @@ Int32 TTVectorFontGlyph::processArc(FontGlyphContour* glyphContour, TT_Outline o
         glyphContour->addPoint(point, normal);
       }
 
-      for (register Int32 j = 1; j < steps; ++j, t += dt) {
+      for (Int32 j = 1; j < steps; ++j, t += dt) {
         tt       = 1. - t;
         t1       = tt * tt;
         t2       = 2. * t * tt;


### PR DESCRIPTION
This PR fixes some errors on VS 2022.
- Missing includes
- Removing deprecated register keywords 